### PR TITLE
[DrawCustom2DIsometricXYZGrid] 에디터에서 기즈모를 사용해 커스텀 그리드 그리기

### DIFF
--- a/Assets/Scenes/UnpackingSample.unity
+++ b/Assets/Scenes/UnpackingSample.unity
@@ -152,8 +152,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 15ff037792ef2294bab5d2593c928165, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_GridSize: {x: 2, y: 2, z: 2}
-  m_GridColor: {r: 0.45882356, g: 0.45882356, b: 0.45882356, a: 1}
+  m_GridSize: {x: 5, y: 5, z: 5}
+  m_GridColor: {r: 0.2784314, g: 0.2784314, b: 0.2784314, a: 1}
 --- !u!4 &1423807868
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/UnpackingSample.unity
+++ b/Assets/Scenes/UnpackingSample.unity
@@ -1,0 +1,308 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 3
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 0
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &1423807866
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1423807868}
+  - component: {fileID: 1423807867}
+  m_Layer: 0
+  m_Name: GridSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1423807867
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1423807866}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 15ff037792ef2294bab5d2593c928165, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_GridSize: {x: 2, y: 2, z: 2}
+  m_GridColor: {r: 0.45882356, g: 0.45882356, b: 0.45882356, a: 1}
+--- !u!4 &1423807868
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1423807866}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2132601294
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2132601297}
+  - component: {fileID: 2132601296}
+  - component: {fileID: 2132601295}
+  - component: {fileID: 2132601298}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &2132601295
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2132601294}
+  m_Enabled: 1
+--- !u!20 &2132601296
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2132601294}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 1
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &2132601297
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2132601294}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2132601298
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2132601294}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+  m_TaaSettings:
+    quality: 3
+    frameInfluence: 0.1
+    jitterScale: 1
+    mipBias: 0
+    varianceClampScale: 0.9
+    contrastAdaptiveSharpening: 0

--- a/Assets/Scenes/UnpackingSample.unity.meta
+++ b/Assets/Scenes/UnpackingSample.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: aaa6da055e8078f4eb01d083e00863be
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Editor.meta
+++ b/Assets/Scripts/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c13a23aa23b6b7f41b636d6ef2b29af5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Editor/WpGridSystemEditor.cs
+++ b/Assets/Scripts/Editor/WpGridSystemEditor.cs
@@ -42,6 +42,7 @@ public class WpGridSystemEditor : Editor
         var size = gridSystem.GridSize;
         var origin = gridSystem.transform.position;
 
+        // draw outside grid
         Gizmos.color = gridSystem.GridColor;
         Gizmos.DrawLineStrip(new Vector3[]
         {
@@ -59,6 +60,8 @@ public class WpGridSystemEditor : Editor
             origin, origin + new Vector3(-size.x, -.5f * size.x)
         });
 
+        // draw inside grid
+        // 내부 그리드 선은 scene view의 사이즈가 클수록 옅게 조정됩니다
         float min = 2.4f, max = 24f;
         var gridColor = gridSystem.GridColor;
         gridColor.a = 1 - Mathf.LinearToGammaSpace((sceneView.size - min) / (max - min));

--- a/Assets/Scripts/Editor/WpGridSystemEditor.cs
+++ b/Assets/Scripts/Editor/WpGridSystemEditor.cs
@@ -40,25 +40,23 @@ public class WpGridSystemEditor : Editor
         }
 
         var size = gridSystem.GridSize;
+        var origin = gridSystem.transform.position;
 
         Gizmos.color = gridSystem.GridColor;
         Gizmos.DrawLineStrip(new Vector3[]
         {
-            new(0, size.y),
-            new(size.z, size.y + -.5f * size.z),
-            new(size.z, -.5f * size.z),
-            new(-size.x + size.z, -.5f * (size.x + size.z)),
-            new(-size.x, -.5f * size.x),
-            new(-size.x, size.y + -.5f * size.x)
+            origin + new Vector3(0, size.y),
+            origin + new Vector3(size.z, size.y + -.5f * size.z),
+            origin + new Vector3(size.z, -.5f * size.z),
+            origin + new Vector3(-size.x + size.z, -.5f * (size.x + size.z)),
+            origin + new Vector3(-size.x, -.5f * size.x),
+            origin + new Vector3(-size.x, size.y + -.5f * size.x)
         }, true);
         Gizmos.DrawLineList(new Vector3[]
         {
-            Vector3.zero,
-            new(0, size.y),
-            Vector3.zero,
-            new(size.z, -.5f * size.z),
-            Vector3.zero,
-            new(-size.x, -.5f * size.x)
+            origin, origin + new Vector3(0, size.y),
+            origin, origin + new Vector3(size.z, -.5f * size.z),
+            origin, origin + new Vector3(-size.x, -.5f * size.x)
         });
 
         float min = 2.4f, max = 24f;
@@ -68,31 +66,31 @@ public class WpGridSystemEditor : Editor
         for (var i = 1; i < size.x; i++)
         {
             Gizmos.DrawLine(
-                new Vector3(-i, -.5f * i),
-                new Vector3(-i, size.y - .5f * i));
+                origin + new Vector3(-i, -.5f * i),
+                origin + new Vector3(-i, size.y - .5f * i));
             Gizmos.DrawLine(
-                new Vector3(-i, -.5f * i),
-                new Vector3(size.z - i, -.5f * (size.z + i)));
+                origin + new Vector3(-i, -.5f * i),
+                origin + new Vector3(size.z - i, -.5f * (size.z + i)));
         }
 
         for (var i = 1; i < size.y; i++)
         {
             Gizmos.DrawLine(
-                new Vector3(0, i),
-                new Vector3(-size.x, -.5f * size.x + i));
+                origin + new Vector3(0, i),
+                origin + new Vector3(-size.x, -.5f * size.x + i));
             Gizmos.DrawLine(
-                new Vector3(0, i),
-                new Vector3(size.z, -.5f * size.z + i));
+                origin + new Vector3(0, i),
+                origin + new Vector3(size.z, -.5f * size.z + i));
         }
 
         for (var i = 1; i < size.z; i++)
         {
             Gizmos.DrawLine(
-                new Vector3(i, -.5f * i),
-                new Vector3(i, size.y - .5f * i));
+                origin + new Vector3(i, -.5f * i),
+                origin + new Vector3(i, size.y - .5f * i));
             Gizmos.DrawLine(
-                new Vector3(i, -.5f * i),
-                new Vector3(-size.x + i, -.5f * (size.x + i)));
+                origin + new Vector3(i, -.5f * i),
+                origin + new Vector3(-size.x + i, -.5f * (size.x + i)));
         }
     }
 

--- a/Assets/Scripts/Editor/WpGridSystemEditor.cs
+++ b/Assets/Scripts/Editor/WpGridSystemEditor.cs
@@ -60,6 +60,40 @@ public class WpGridSystemEditor : Editor
             Vector3.zero,
             new(-size.x, -.5f * size.x)
         });
+
+        float min = 2.4f, max = 24f;
+        var gridColor = gridSystem.GridColor;
+        gridColor.a = 1 - Mathf.LinearToGammaSpace((sceneView.size - min) / (max - min));
+        Gizmos.color = gridColor;
+        for (var i = 1; i < size.x; i++)
+        {
+            Gizmos.DrawLine(
+                new Vector3(-i, -.5f * i),
+                new Vector3(-i, size.y - .5f * i));
+            Gizmos.DrawLine(
+                new Vector3(-i, -.5f * i),
+                new Vector3(size.z - i, -.5f * (size.z + i)));
+        }
+
+        for (var i = 1; i < size.y; i++)
+        {
+            Gizmos.DrawLine(
+                new Vector3(0, i),
+                new Vector3(-size.x, -.5f * size.x + i));
+            Gizmos.DrawLine(
+                new Vector3(0, i),
+                new Vector3(size.z, -.5f * size.z + i));
+        }
+
+        for (var i = 1; i < size.z; i++)
+        {
+            Gizmos.DrawLine(
+                new Vector3(i, -.5f * i),
+                new Vector3(i, size.y - .5f * i));
+            Gizmos.DrawLine(
+                new Vector3(i, -.5f * i),
+                new Vector3(-size.x + i, -.5f * (size.x + i)));
+        }
     }
 
     #endregion

--- a/Assets/Scripts/Editor/WpGridSystemEditor.cs
+++ b/Assets/Scripts/Editor/WpGridSystemEditor.cs
@@ -41,23 +41,26 @@ public class WpGridSystemEditor : Editor
 
         var size = gridSystem.GridSize;
         var origin = gridSystem.transform.position;
+        var yAxis = gridSystem.transform.up;
+        var xAxis = -gridSystem.transform.right - 0.5f * gridSystem.transform.up;
+        var zAxis = gridSystem.transform.right - 0.5f * gridSystem.transform.up;
 
         // draw outside grid
         Gizmos.color = gridSystem.GridColor;
         Gizmos.DrawLineStrip(new Vector3[]
         {
-            origin + new Vector3(0, size.y),
-            origin + new Vector3(size.z, size.y + -.5f * size.z),
-            origin + new Vector3(size.z, -.5f * size.z),
-            origin + new Vector3(-size.x + size.z, -.5f * (size.x + size.z)),
-            origin + new Vector3(-size.x, -.5f * size.x),
-            origin + new Vector3(-size.x, size.y + -.5f * size.x)
+            origin + size.y * yAxis,
+            origin + size.y * yAxis + size.z * zAxis,
+            origin + size.z * zAxis,
+            origin + size.x * xAxis + size.z * zAxis,
+            origin + size.x * xAxis,
+            origin + size.x * xAxis + size.y * yAxis
         }, true);
         Gizmos.DrawLineList(new Vector3[]
         {
-            origin, origin + new Vector3(0, size.y),
-            origin, origin + new Vector3(size.z, -.5f * size.z),
-            origin, origin + new Vector3(-size.x, -.5f * size.x)
+            origin, size.x * xAxis,
+            origin, size.y * yAxis,
+            origin, size.z * zAxis
         });
 
         // draw inside grid
@@ -69,31 +72,31 @@ public class WpGridSystemEditor : Editor
         for (var i = 1; i < size.x; i++)
         {
             Gizmos.DrawLine(
-                origin + new Vector3(-i, -.5f * i),
-                origin + new Vector3(-i, size.y - .5f * i));
+                origin + i * xAxis,
+                origin + i * xAxis + size.y * yAxis);
             Gizmos.DrawLine(
-                origin + new Vector3(-i, -.5f * i),
-                origin + new Vector3(size.z - i, -.5f * (size.z + i)));
+                origin + i * xAxis,
+                origin + i * xAxis + size.z * zAxis);
         }
 
         for (var i = 1; i < size.y; i++)
         {
             Gizmos.DrawLine(
-                origin + new Vector3(0, i),
-                origin + new Vector3(-size.x, -.5f * size.x + i));
+                origin + i * yAxis,
+                origin + i * yAxis + size.x * xAxis);
             Gizmos.DrawLine(
-                origin + new Vector3(0, i),
-                origin + new Vector3(size.z, -.5f * size.z + i));
+                origin + i * yAxis,
+                origin + i * yAxis + size.z * zAxis);
         }
 
         for (var i = 1; i < size.z; i++)
         {
             Gizmos.DrawLine(
-                origin + new Vector3(i, -.5f * i),
-                origin + new Vector3(i, size.y - .5f * i));
+                origin + i * zAxis,
+                origin + i * zAxis + size.y * yAxis);
             Gizmos.DrawLine(
-                origin + new Vector3(i, -.5f * i),
-                origin + new Vector3(-size.x + i, -.5f * (size.x + i)));
+                origin + i * zAxis,
+                origin + i * zAxis + size.x * xAxis);
         }
     }
 

--- a/Assets/Scripts/Editor/WpGridSystemEditor.cs
+++ b/Assets/Scripts/Editor/WpGridSystemEditor.cs
@@ -65,9 +65,9 @@ public class WpGridSystemEditor : Editor
 
         // draw inside grid
         // 내부 그리드 선은 scene view의 사이즈가 클수록 옅게 조정됩니다
-        float min = 2.4f, max = 24f;
+        float min = 4.8f, max = 48f;
         var gridColor = gridSystem.GridColor;
-        gridColor.a = 1 - Mathf.LinearToGammaSpace((sceneView.size - min) / (max - min));
+        gridColor.a = 1 - Mathf.LinearToGammaSpace((sceneView.cameraDistance - min) / (max - min));
         Gizmos.color = gridColor;
         for (var i = 1; i < size.x; i++)
         {

--- a/Assets/Scripts/Editor/WpGridSystemEditor.cs
+++ b/Assets/Scripts/Editor/WpGridSystemEditor.cs
@@ -1,0 +1,66 @@
+using UnityEditor;
+using UnityEngine;
+
+[CustomEditor(typeof(WpGridSystem))]
+public class WpGridSystemEditor : Editor
+{
+    #region Private Field
+
+    private static bool? k_CachedSceneViewGridVisibility;
+
+    #endregion
+
+    #region Private Methods
+
+    [DrawGizmo(GizmoType.NonSelected | GizmoType.Selected)]
+    private static void DrawGizmos(WpGridSystem gridSystem, GizmoType gizmoType)
+    {
+        var sceneView = SceneView.currentDrawingSceneView;
+
+        if (sceneView is null)
+            return;
+
+        // GridSystem의 Gizmo를 표시하는 동안은 SceneView의 Grid를 비활성화
+        if (gizmoType.HasFlag(GizmoType.NonSelected))
+        {
+            if (k_CachedSceneViewGridVisibility.HasValue)
+            {
+                sceneView.showGrid = k_CachedSceneViewGridVisibility.Value;
+                k_CachedSceneViewGridVisibility = null;
+            }
+
+            return;
+        }
+
+        if (gizmoType.HasFlag(GizmoType.Selected)
+            && !k_CachedSceneViewGridVisibility.HasValue)
+        {
+            k_CachedSceneViewGridVisibility = sceneView.showGrid;
+            sceneView.showGrid = false;
+        }
+
+        var size = gridSystem.GridSize;
+
+        Gizmos.color = gridSystem.GridColor;
+        Gizmos.DrawLineStrip(new Vector3[]
+        {
+            new(0, size.y),
+            new(size.z, size.y + -.5f * size.z),
+            new(size.z, -.5f * size.z),
+            new(-size.x + size.z, -.5f * (size.x + size.z)),
+            new(-size.x, -.5f * size.x),
+            new(-size.x, size.y + -.5f * size.x)
+        }, true);
+        Gizmos.DrawLineList(new Vector3[]
+        {
+            Vector3.zero,
+            new(0, size.y),
+            Vector3.zero,
+            new(size.z, -.5f * size.z),
+            Vector3.zero,
+            new(-size.x, -.5f * size.x)
+        });
+    }
+
+    #endregion
+}

--- a/Assets/Scripts/Editor/WpGridSystemEditor.cs.meta
+++ b/Assets/Scripts/Editor/WpGridSystemEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2b34782a08ce01345a417235a2caf709
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/GridSystem.meta
+++ b/Assets/Scripts/GridSystem.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 467aa71640dfa634a9ecf8da5897fd6b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/GridSystem/WpGridSystem.cs
+++ b/Assets/Scripts/GridSystem/WpGridSystem.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+
+public class WpGridSystem : MonoBehaviour
+{
+    #region Serialize Field
+
+    [SerializeField] private Vector3Int m_GridSize;
+    [SerializeField] private Color m_GridColor;
+
+    #endregion
+
+
+    #region Public Property
+
+    public Vector3Int GridSize => m_GridSize;
+    public Color GridColor => m_GridColor;
+
+    #endregion
+}

--- a/Assets/Scripts/GridSystem/WpGridSystem.cs.meta
+++ b/Assets/Scripts/GridSystem/WpGridSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 15ff037792ef2294bab5d2593c928165
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Settings/URP-Balanced.asset
+++ b/Assets/Settings/URP-Balanced.asset
@@ -12,8 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bf2edee5c58d82540a51f03df9d42094, type: 3}
   m_Name: URP-Balanced
   m_EditorClassIdentifier: 
-  k_AssetVersion: 9
-  k_AssetPreviousVersion: 9
+  k_AssetVersion: 11
+  k_AssetPreviousVersion: 11
   m_RendererType: 1
   m_RendererData: {fileID: 0}
   m_RendererDataList:
@@ -23,10 +23,16 @@ MonoBehaviour:
   m_RequireOpaqueTexture: 0
   m_OpaqueDownsampling: 1
   m_SupportsTerrainHoles: 1
-  m_StoreActionsOptimization: 0
   m_SupportsHDR: 1
+  m_HDRColorBufferPrecision: 0
   m_MSAA: 1
   m_RenderScale: 1
+  m_UpscalingFilter: 0
+  m_FsrOverrideSharpness: 0
+  m_FsrSharpness: 0.92
+  m_EnableLODCrossFade: 1
+  m_LODCrossFadeDitheringType: 1
+  m_ShEvalMode: 0
   m_MainLightRenderingMode: 1
   m_MainLightShadowsSupported: 1
   m_MainLightShadowmapResolution: 1024
@@ -47,23 +53,58 @@ MonoBehaviour:
   m_CascadeBorder: 0.1
   m_ShadowDepthBias: 1
   m_ShadowNormalBias: 1
+  m_AnyShadowsSupported: 1
   m_SoftShadowsSupported: 1
+  m_ConservativeEnclosingSphere: 0
+  m_NumIterationsEnclosingSphere: 64
+  m_SoftShadowQuality: 2
   m_AdditionalLightsCookieResolution: 512
   m_AdditionalLightsCookieFormat: 1
   m_UseSRPBatcher: 1
   m_SupportsDynamicBatching: 0
   m_MixedLightingSupported: 1
+  m_SupportsLightCookies: 1
   m_SupportsLightLayers: 0
   m_DebugLevel: 0
+  m_StoreActionsOptimization: 0
+  m_EnableRenderGraph: 0
   m_UseAdaptivePerformance: 1
   m_ColorGradingMode: 0
   m_ColorGradingLutSize: 32
   m_UseFastSRGBLinearConversion: 0
+  m_SupportDataDrivenLensFlare: 1
   m_ShadowType: 1
   m_LocalShadowsSupported: 0
   m_LocalShadowsAtlasResolution: 256
   m_MaxPixelLights: 0
   m_ShadowAtlasResolution: 256
-  m_ShaderVariantLogLevel: 0
   m_VolumeFrameworkUpdateMode: 0
+  m_Textures:
+    blueNoise64LTex: {fileID: 2800000, guid: e3d24661c1e055f45a7560c033dbb837, type: 3}
+    bayerMatrixTex: {fileID: 2800000, guid: f9ee4ed84c1d10c49aabb9b210b0fc44, type: 3}
+  m_PrefilteringModeMainLightShadows: 1
+  m_PrefilteringModeAdditionalLight: 4
+  m_PrefilteringModeAdditionalLightShadows: 1
+  m_PrefilterXRKeywords: 0
+  m_PrefilteringModeForwardPlus: 1
+  m_PrefilteringModeDeferredRendering: 1
+  m_PrefilteringModeScreenSpaceOcclusion: 1
+  m_PrefilterDebugKeywords: 0
+  m_PrefilterWriteRenderingLayers: 0
+  m_PrefilterHDROutput: 0
+  m_PrefilterSSAODepthNormals: 0
+  m_PrefilterSSAOSourceDepthLow: 0
+  m_PrefilterSSAOSourceDepthMedium: 0
+  m_PrefilterSSAOSourceDepthHigh: 0
+  m_PrefilterSSAOInterleaved: 0
+  m_PrefilterSSAOBlueNoise: 0
+  m_PrefilterSSAOSampleCountLow: 0
+  m_PrefilterSSAOSampleCountMedium: 0
+  m_PrefilterSSAOSampleCountHigh: 0
+  m_PrefilterDBufferMRT1: 0
+  m_PrefilterDBufferMRT2: 0
+  m_PrefilterDBufferMRT3: 0
+  m_PrefilterScreenCoord: 0
+  m_PrefilterNativeRenderPass: 0
+  m_ShaderVariantLogLevel: 0
   m_ShadowCascades: 0

--- a/Assets/Settings/URP-Performant.asset
+++ b/Assets/Settings/URP-Performant.asset
@@ -12,8 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bf2edee5c58d82540a51f03df9d42094, type: 3}
   m_Name: URP-Performant
   m_EditorClassIdentifier: 
-  k_AssetVersion: 9
-  k_AssetPreviousVersion: 9
+  k_AssetVersion: 11
+  k_AssetPreviousVersion: 11
   m_RendererType: 1
   m_RendererData: {fileID: 0}
   m_RendererDataList:
@@ -23,10 +23,16 @@ MonoBehaviour:
   m_RequireOpaqueTexture: 0
   m_OpaqueDownsampling: 1
   m_SupportsTerrainHoles: 1
-  m_StoreActionsOptimization: 0
   m_SupportsHDR: 0
+  m_HDRColorBufferPrecision: 0
   m_MSAA: 1
   m_RenderScale: 1
+  m_UpscalingFilter: 0
+  m_FsrOverrideSharpness: 0
+  m_FsrSharpness: 0.92
+  m_EnableLODCrossFade: 1
+  m_LODCrossFadeDitheringType: 1
+  m_ShEvalMode: 0
   m_MainLightRenderingMode: 1
   m_MainLightShadowsSupported: 0
   m_MainLightShadowmapResolution: 1024
@@ -47,23 +53,58 @@ MonoBehaviour:
   m_CascadeBorder: 0.1
   m_ShadowDepthBias: 1
   m_ShadowNormalBias: 1
+  m_AnyShadowsSupported: 1
   m_SoftShadowsSupported: 0
+  m_ConservativeEnclosingSphere: 0
+  m_NumIterationsEnclosingSphere: 64
+  m_SoftShadowQuality: 2
   m_AdditionalLightsCookieResolution: 2048
   m_AdditionalLightsCookieFormat: 3
   m_UseSRPBatcher: 1
   m_SupportsDynamicBatching: 0
   m_MixedLightingSupported: 1
+  m_SupportsLightCookies: 1
   m_SupportsLightLayers: 0
   m_DebugLevel: 0
+  m_StoreActionsOptimization: 0
+  m_EnableRenderGraph: 0
   m_UseAdaptivePerformance: 1
   m_ColorGradingMode: 0
   m_ColorGradingLutSize: 16
   m_UseFastSRGBLinearConversion: 0
+  m_SupportDataDrivenLensFlare: 1
   m_ShadowType: 1
   m_LocalShadowsSupported: 0
   m_LocalShadowsAtlasResolution: 256
   m_MaxPixelLights: 0
   m_ShadowAtlasResolution: 256
-  m_ShaderVariantLogLevel: 0
   m_VolumeFrameworkUpdateMode: 0
+  m_Textures:
+    blueNoise64LTex: {fileID: 2800000, guid: e3d24661c1e055f45a7560c033dbb837, type: 3}
+    bayerMatrixTex: {fileID: 2800000, guid: f9ee4ed84c1d10c49aabb9b210b0fc44, type: 3}
+  m_PrefilteringModeMainLightShadows: 1
+  m_PrefilteringModeAdditionalLight: 4
+  m_PrefilteringModeAdditionalLightShadows: 1
+  m_PrefilterXRKeywords: 0
+  m_PrefilteringModeForwardPlus: 1
+  m_PrefilteringModeDeferredRendering: 1
+  m_PrefilteringModeScreenSpaceOcclusion: 1
+  m_PrefilterDebugKeywords: 0
+  m_PrefilterWriteRenderingLayers: 0
+  m_PrefilterHDROutput: 0
+  m_PrefilterSSAODepthNormals: 0
+  m_PrefilterSSAOSourceDepthLow: 0
+  m_PrefilterSSAOSourceDepthMedium: 0
+  m_PrefilterSSAOSourceDepthHigh: 0
+  m_PrefilterSSAOInterleaved: 0
+  m_PrefilterSSAOBlueNoise: 0
+  m_PrefilterSSAOSampleCountLow: 0
+  m_PrefilterSSAOSampleCountMedium: 0
+  m_PrefilterSSAOSampleCountHigh: 0
+  m_PrefilterDBufferMRT1: 0
+  m_PrefilterDBufferMRT2: 0
+  m_PrefilterDBufferMRT3: 0
+  m_PrefilterScreenCoord: 0
+  m_PrefilterNativeRenderPass: 0
+  m_ShaderVariantLogLevel: 0
   m_ShadowCascades: 0

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "com.unity.collab-proxy": "2.0.5",
+    "com.unity.feature.2d": "2.0.0",
     "com.unity.ide.rider": "3.0.24",
     "com.unity.ide.visualstudio": "2.0.18",
     "com.unity.ide.vscode": "1.2.5",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,5 +1,99 @@
 {
   "dependencies": {
+    "com.unity.2d.animation": {
+      "version": "9.0.3",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.2d.common": "8.0.1",
+        "com.unity.2d.sprite": "1.0.0",
+        "com.unity.collections": "1.1.0",
+        "com.unity.modules.animation": "1.0.0",
+        "com.unity.modules.uielements": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.2d.aseprite": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.2d.sprite": "1.0.0",
+        "com.unity.2d.common": "6.0.6",
+        "com.unity.mathematics": "1.2.6",
+        "com.unity.modules.animation": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.2d.common": {
+      "version": "8.0.1",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.2d.sprite": "1.0.0",
+        "com.unity.mathematics": "1.1.0",
+        "com.unity.modules.uielements": "1.0.0",
+        "com.unity.modules.animation": "1.0.0",
+        "com.unity.burst": "1.7.3"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.2d.pixel-perfect": {
+      "version": "5.0.3",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.2d.psdimporter": {
+      "version": "8.0.2",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.2d.animation": "9.0.1",
+        "com.unity.2d.common": "8.0.1",
+        "com.unity.2d.sprite": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.2d.sprite": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {}
+    },
+    "com.unity.2d.spriteshape": {
+      "version": "9.0.2",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.mathematics": "1.1.0",
+        "com.unity.2d.common": "8.0.1",
+        "com.unity.modules.physics2d": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.2d.tilemap": {
+      "version": "1.0.0",
+      "depth": 1,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.modules.tilemap": "1.0.0",
+        "com.unity.modules.uielements": "1.0.0"
+      }
+    },
+    "com.unity.2d.tilemap.extras": {
+      "version": "3.1.0",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.modules.tilemap": "1.0.0",
+        "com.unity.2d.tilemap": "1.0.0",
+        "com.unity.ugui": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.burst": {
       "version": "1.8.7",
       "depth": 1,
@@ -16,12 +110,37 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.collections": {
+      "version": "1.2.4",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.burst": "1.6.6",
+        "com.unity.test-framework": "1.1.31"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.ext.nunit": {
       "version": "1.0.6",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
+    },
+    "com.unity.feature.2d": {
+      "version": "2.0.0",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.2d.animation": "9.0.3",
+        "com.unity.2d.pixel-perfect": "5.0.3",
+        "com.unity.2d.psdimporter": "8.0.2",
+        "com.unity.2d.sprite": "1.0.0",
+        "com.unity.2d.spriteshape": "9.0.2",
+        "com.unity.2d.tilemap": "1.0.0",
+        "com.unity.2d.tilemap.extras": "3.1.0",
+        "com.unity.2d.aseprite": "1.0.0"
+      }
     },
     "com.unity.ide.rider": {
       "version": "3.0.24",

--- a/ProjectSettings/EditorSettings.asset
+++ b/ProjectSettings/EditorSettings.asset
@@ -3,33 +3,45 @@
 --- !u!159 &1
 EditorSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 9
-  m_ExternalVersionControlSupport: Visible Meta Files
+  serializedVersion: 12
   m_SerializationMode: 2
   m_LineEndingsForNewScripts: 2
-  m_DefaultBehaviorMode: 0
+  m_DefaultBehaviorMode: 1
   m_PrefabRegularEnvironment: {fileID: 0}
   m_PrefabUIEnvironment: {fileID: 0}
   m_SpritePackerMode: 0
+  m_SpritePackerCacheSize: 10
   m_SpritePackerPaddingPower: 1
+  m_Bc7TextureCompressor: 0
   m_EtcTextureCompressorBehavior: 1
   m_EtcTextureFastCompressor: 1
   m_EtcTextureNormalCompressor: 2
   m_EtcTextureBestCompressor: 4
   m_ProjectGenerationIncludedExtensions: txt;xml;fnt;cd;asmdef;asmref;rsp
   m_ProjectGenerationRootNamespace: 
-  m_CollabEditorSettings:
-    inProgressEnabled: 1
   m_EnableTextureStreamingInEditMode: 1
   m_EnableTextureStreamingInPlayMode: 1
+  m_EnableEditorAsyncCPUTextureLoading: 0
   m_AsyncShaderCompilation: 1
+  m_PrefabModeAllowAutoSave: 1
   m_EnterPlayModeOptionsEnabled: 0
   m_EnterPlayModeOptions: 3
-  m_ShowLightmapResolutionOverlay: 1
+  m_GameObjectNamingDigits: 1
+  m_GameObjectNamingScheme: 0
+  m_AssetNamingUsesSpace: 1
+  m_InspectorUseIMGUIDefaultInspector: 0
   m_UseLegacyProbeSampleCount: 0
+  m_SerializeInlineMappingsOnOneLine: 0
+  m_DisableCookiesInLightmapper: 1
   m_AssetPipelineMode: 1
+  m_RefreshImportMode: 0
   m_CacheServerMode: 0
   m_CacheServerEndpoint: 
   m_CacheServerNamespacePrefix: default
   m_CacheServerEnableDownload: 1
   m_CacheServerEnableUpload: 1
+  m_CacheServerEnableAuth: 0
+  m_CacheServerEnableTls: 0
+  m_CacheServerValidationMode: 2
+  m_CacheServerDownloadBatchSize: 128
+  m_EnableEnlightenBakedGI: 0


### PR DESCRIPTION
Gizmos 모듈을 이용해 에디터에서 커스텀 그리드를 그립니다.

* GridSystem component가 부착된 오브젝트가 선택된 상태여야 확인할 수 있습니다.
* 3차원 Isometric 모양을 2D로 그립니다.
* 오브젝트의 position, rotation에 영향을 받습니다. (scale은 x)
* scene view의 camera distance가 멀어지면 외곽 선은 그대로지만 내부 선은 옅어집니다.

※ 해당 브랜치 첫 커밋에서 프로젝트 설정을 2D로 바꾸고 2D 관련 package를 추가한 내역이 있습니다.
해당 브랜치로 이동 후 git status에 문제가 없는지 한 번 체크해 주시면 좋을 것 같습니다.